### PR TITLE
Implementing suggested improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,4 @@ The following improvements/additions to the macro are in the pipeline.
 * Add a detailed document and in-line comments outlining the macro internal logic
 * Integrate with Open Zeppelin's access control
 * Add support for role based predicates and predicates with different shapes
+* Eliminate pub(crate) Fns from the enforced functions

--- a/access-control-macros/src/lib.rs
+++ b/access-control-macros/src/lib.rs
@@ -15,19 +15,17 @@
 //!     * Syntax-only attribute when used standalone (left in place); instrumentation is performed
 //!       locally by `#[access_control]` so expansion order with other macros stays predictable.
 
-
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
+use std::collections::BTreeSet;
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    Attribute, FnArg, ImplItem, ItemImpl, Meta, Pat, Path, Token, Type,
-    Visibility,
+    Attribute, FnArg, ImplItem, ItemImpl, Meta, Pat, Path, Token, Type, Visibility,
 };
-use std::collections::BTreeSet;
 
 use proc_macro_error::{abort, abort_if_dirty, emit_error, emit_warning, proc_macro_error};
 
@@ -72,7 +70,9 @@ fn env_type_candidates(sig: &syn::Signature) -> Vec<syn::Ident> {
     let mut out = Vec::new();
     for arg in &sig.inputs {
         let FnArg::Typed(pat_ty) = arg else { continue };
-        let Pat::Ident(pat_ident) = &*pat_ty.pat else { continue };
+        let Pat::Ident(pat_ident) = &*pat_ty.pat else {
+            continue;
+        };
 
         // peel references like &Env
         let mut ty: &Type = &*pat_ty.ty;
@@ -144,7 +144,6 @@ fn instrument_block_multi(
     }
 }
 
-
 /// 1) Finds and removes the instances of #[authorized_by(...)] in attrs,
 /// 2) parses it into AuthorizedArgs and pushes it to the output vector,
 /// 3) returns the output vector contained the authorizaed args (or None if malformed attr).
@@ -175,7 +174,6 @@ fn take_all_authorized_args(attrs: &mut Vec<Attribute>) -> Vec<AuthorizedArgs> {
     }
     out
 }
-
 
 fn build_call_path(check_fn: &Path, use_self: bool) -> TokenStream2 {
     if use_self && check_fn.segments.len() == 1 {
@@ -263,7 +261,7 @@ fn instrument_impl_like_multi(
 #[proc_macro_attribute]
 pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Validate syntax but do not instrument here. This is because when evaluating multiple authorized_by attributes
-    // it can cause issues of double instrumentation when #[access_control] processes it later. To avoid any ugly errors 
+    // it can cause issues of double instrumentation when #[access_control] processes it later. To avoid any ugly errors
     // and enforced policies in a single location, the macro instrumentation is uniformly handled through access_control
     if let Err(e) = syn::parse::<AuthorizedArgs>(attr) {
         emit_error!(e.span(), "malformed #[authorized_by(..)]: {}", e);
@@ -294,7 +292,13 @@ pub fn access_control(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 // If we have any authorized_by(..), instrument with *all* predicates
                 let mut had_authorized = false;
                 if !auth_args.is_empty() {
-                    if instrument_impl_like_multi(&m.sig, &mut m.block, &m.sig.ident, &auth_args, true) {
+                    if instrument_impl_like_multi(
+                        &m.sig,
+                        &mut m.block,
+                        &m.sig.ident,
+                        &auth_args,
+                        true,
+                    ) {
                         had_authorized = true;
                     }
                 }

--- a/access-control-macros/src/lib.rs
+++ b/access-control-macros/src/lib.rs
@@ -17,7 +17,7 @@ use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    Attribute, FnArg, ImplItem, ImplItemFn, Item, ItemFn, ItemImpl, Meta, Pat, Path, Token, Type,
+    Attribute, FnArg, ImplItem, ImplItemFn, ItemFn, ItemImpl, Meta, Pat, Path, Token, Type,
     Visibility,
 };
 
@@ -37,6 +37,8 @@ struct AuthorizedArgs {
     arg: syn::Ident,
     check_fn: Path,
 }
+
+/// The parser enforces the format: `<ident> , <path>`.
 impl Parse for AuthorizedArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let arg: syn::Ident = input.parse()?;
@@ -46,34 +48,20 @@ impl Parse for AuthorizedArgs {
     }
 }
 
-fn ident_eq(a: &syn::Ident, b: &syn::Ident) -> bool {
-    a.to_string() == b.to_string()
-}
-
-fn param_exists(sig: &syn::Signature, want: &syn::Ident) -> bool {
-    sig.inputs.iter().any(|arg| match arg {
-        FnArg::Typed(pat_ty) => {
-            if let Pat::Ident(p) = &*pat_ty.pat {
-                ident_eq(&p.ident, want)
-            } else {
-                false
-            }
-        }
-        FnArg::Receiver(_) => false,
+/// Iterates over the function signature's arguments and returns the "desired" parameter, if it exists.
+fn find_param_ident(sig: &syn::Signature, desired: &str) -> Option<syn::Ident> {
+    sig.inputs.iter().find_map(|arg| match arg {
+        FnArg::Typed(pat_ty) => match &*pat_ty.pat {
+            Pat::Ident(p) if p.ident == desired => Some(p.ident.clone()),
+            _ => None,
+        },
+        FnArg::Receiver(_) => None, // skip for 'self'
     })
 }
 
-fn find_param_ident(sig: &syn::Signature, name: &str) -> Option<syn::Ident> {
-    for arg in &sig.inputs {
-        if let FnArg::Typed(pat_ty) = arg {
-            if let Pat::Ident(pat) = &*pat_ty.pat {
-                if pat.ident == name {
-                    return Some(pat.ident.clone());
-                }
-            }
-        }
-    }
-    None
+/// Returns true if desired parameter exists within the function signature.
+fn param_exists(sig: &syn::Signature, desired: &syn::Ident) -> bool {
+    find_param_ident(sig, &desired.to_string()).is_some()
 }
 
 /// Return the parameter identifiers whose *spelled* type is `Env` (or `&Env`, or `soroban_sdk::Env`).
@@ -115,6 +103,10 @@ fn find_env_ident_hybrid(sig: &syn::Signature) -> Option<syn::Ident> {
     }
 }
 
+/// Returns a boxed block that:
+/// 1) runs the predicate,
+/// 2) calls `require_auth()` on the subject,
+/// 3) then executes the original body.
 fn instrument_block(
     body: &syn::Block,
     call_path: TokenStream2,
@@ -139,6 +131,9 @@ fn instrument_block(
     }
 }
 
+/// 1) Finds and removes the first #[authorized_by(...)] in attrs,
+/// 2) parses it into AuthorizedArgs,
+/// 3) returns Some(args) (or None if malformed attr).
 fn take_authorized_args(attrs: &mut Vec<Attribute>) -> Option<AuthorizedArgs> {
     let idx = attrs.iter().position(|a| a.path().is_ident("authorized_by"))?;
     let attr = attrs.remove(idx);
@@ -160,57 +155,76 @@ fn take_authorized_args(attrs: &mut Vec<Attribute>) -> Option<AuthorizedArgs> {
     }
 }
 
-fn try_instrument_method(m: &mut ImplItemFn, args: &AuthorizedArgs) -> Option<()> {
-    if !param_exists(&m.sig, &args.arg) {
-        emit_warning!(
-            args.arg.span(),
-            "skipping #[authorized_by]: parameter `{}` not found on `{}` (generated wrapper?)",
-            args.arg,
-            m.sig.ident
-        );
-        return None;
-    }
-    let env_ident = match find_env_ident_hybrid(&m.sig) {
-        Some(id) => id,
-        None => {
-            // See if we can give a better hint (ambiguous vs missing) for ergonomics
-            let cands = env_type_candidates(&m.sig);
-            if cands.len() > 1 {
-                emit_warning!(
-                    m.sig.span(),
-                    "skipping #[authorized_by]: multiple `Env`-typed parameters on `{}`; \
-                     please name the desired one `env`",
-                    m.sig.ident
-                );
-            } else {
-                emit_warning!(
-                    m.sig.span(),
-                    "skipping #[authorized_by]: no `Env` parameter found on `{}`; leaving unchanged",
-                    m.sig.ident
-                );
-            }
-            return None;
-        }
-    };
-    let call_path = if args.check_fn.segments.len() == 1 {
-        let ident = &args.check_fn.segments[0].ident;
+fn build_call_path(check_fn: &Path, use_self: bool) -> TokenStream2 {
+    if use_self && check_fn.segments.len() == 1 {
+        let ident = &check_fn.segments[0].ident;
         quote! { Self::#ident }
     } else {
-        let p = &args.check_fn;
+        let p = check_fn;
         quote! { #p }
-    };
-    let arg = &args.arg;
-    let body = &m.block;
-    m.block = *instrument_block(body, call_path, &env_ident, arg, m.sig.span());
-    Some(())
+    }
 }
 
-/// Standalone attribute. Never errors on placement: falls back to no-op
-/// so rust-analyzer expansion order doesn't spam diagnostics.
+fn get_env_ident_or_warn(sig: &syn::Signature, fn_name: &syn::Ident) -> Option<syn::Ident> {
+    if let Some(id) = find_env_ident_hybrid(sig) {
+        return Some(id);
+    }
+    let cands = env_type_candidates(sig);
+    if cands.len() > 1 {
+        emit_warning!(
+            sig.span(),
+            "skipping #[authorized_by]: multiple `Env`-typed parameters on `{}`; \
+             please name the desired one `env`",
+            fn_name
+        );
+    } else {
+        emit_warning!(
+            sig.span(),
+            "skipping #[authorized_by]: no `Env` parameter found on `{}`; leaving unchanged",
+            fn_name
+        );
+    }
+    None
+}
+
+fn ensure_param_or_warn(sig: &syn::Signature, fn_name: &syn::Ident, desired: &syn::Ident) -> bool {
+    if param_exists(sig, desired) {
+        return true;
+    }
+    emit_warning!(
+        desired.span(),
+        "skipping #[authorized_by]: parameter `{}` not found on `{}` (generated wrapper?)",
+        desired,
+        fn_name
+    );
+    false
+}
+
+///
+fn instrument_impl_like(
+    sig: &syn::Signature,
+    block: &mut syn::Block,
+    fn_name: &syn::Ident,
+    args: &AuthorizedArgs,
+    use_self: bool,
+) -> bool {
+    if !ensure_param_or_warn(sig, fn_name, &args.arg) {
+        return false;
+    }
+    let env_ident = match get_env_ident_or_warn(sig, fn_name) {
+        Some(e) => e,
+        None => return false,
+    };
+    let call_path = build_call_path(&args.check_fn, use_self);
+    let arg = &args.arg;
+    let body = &*block; // borrow before replace
+    *block = *instrument_block(body, call_path, &env_ident, arg, sig.span());
+    true
+}
+
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
-    // Parse args; if malformed, that's a real error.
     let args = match syn::parse::<AuthorizedArgs>(attr) {
         Ok(a) => a,
         Err(e) => {
@@ -219,106 +233,36 @@ pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    // Case 1: method inside an `impl`
+    // impl method path
     if let Ok(mut m) = syn::parse::<ImplItemFn>(item.clone()) {
-        // only instrument if both `env` and requested param exist
-        if let Some(env_ident) = find_env_ident_hybrid(&m.sig) {
-            if param_exists(&m.sig, &args.arg) {
-                let call_path = if args.check_fn.segments.len() == 1 {
-                    let ident = &args.check_fn.segments[0].ident;
-                    quote! { Self::#ident }
-                } else {
-                    let p = &args.check_fn;
-                    quote! { #p }
-                };
-                let arg = &args.arg;
-                let body = &m.block;
-                m.block = *instrument_block(body, call_path, &env_ident, arg, m.sig.span());
-            } else {
-                // param not found – leave unchanged (avoid RA errors)
-                emit_warning!(
-                    args.arg.span(),
-                    "skipping #[authorized_by]: parameter `{}` not found on `{}`; leaving unchanged",
-                    args.arg, m.sig.ident
-                );
-            }
-        } else {
-            let cands = env_type_candidates(&m.sig);
-            if cands.len() > 1 {
-                emit_warning!(
-                    m.sig.span(),
-                    "skipping #[authorized_by]: multiple `Env`-typed parameters on `{}`; \
-                     please name the desired one `env`",
-                    m.sig.ident
-                );
-            } else {
-                emit_warning!(
-                    m.sig.span(),
-                    "skipping #[authorized_by]: no `Env` parameter on `{}`; leaving unchanged",
-                    m.sig.ident
-                );
-            }
-        }
+        let _ = instrument_impl_like(&m.sig, &mut m.block, &m.sig.ident, &args, /*use_self=*/ true);
         return TokenStream::from(quote!(#m));
     }
 
-    // Case 2: free function
+    // free function path
     if let Ok(mut f) = syn::parse::<ItemFn>(item.clone()) {
-        if let Some(env_ident) = find_env_ident_hybrid(&f.sig) {
-            if param_exists(&f.sig, &args.arg) {
-                let call_path = {
-                    let p = &args.check_fn;
-                    quote! { #p }
-                };
-                let arg = &args.arg;
-                let body = &f.block;
-                f.block = instrument_block(body, call_path, &env_ident, arg, f.sig.span());
-            } else {
-                emit_warning!(
-                    args.arg.span(),
-                    "skipping #[authorized_by]: parameter `{}` not found on function `{}`; leaving unchanged",
-                    args.arg, f.sig.ident
-                );
-            }
-        } else {
-            let cands = env_type_candidates(&f.sig);
-            if cands.len() > 1 {
-                emit_warning!(
-                    f.sig.span(),
-                    "skipping #[authorized_by]: multiple `Env`-typed parameters on `{}`; \
-                     please name the desired one `env`",
-                    f.sig.ident
-                );
-            } else {
-                emit_warning!(
-                    f.sig.span(),
-                    "skipping #[authorized_by]: no `Env` parameter on `{}`; leaving unchanged",
-                    f.sig.ident
-                );
-            }
-        }
+        let _ = instrument_impl_like(&f.sig, &mut f.block, &f.sig.ident, &args, /*use_self=*/ false);
         return TokenStream::from(quote!(#f));
     }
 
-    // Not a function/method → just return unchanged (no error).
+    // Not a function/method → no-op
     item
 }
 
-/// Apply to an `impl` block.
+/// Apply to an `contractimpl` block.
 /// Instruments #[authorized_by(...)] in place and removes the attribute;
 /// then enforces that public functions have either #[no_access_control]
 /// or #[authorized_by(...)].
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn access_control(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    // impl block path
     if let Ok(mut impl_block) = syn::parse::<ItemImpl>(item.clone()) {
         for it in &mut impl_block.items {
             if let ImplItem::Fn(m) = it {
                 // instrument & strip #[authorized_by(...)] if present
                 let mut had_authorized = false;
                 if let Some(args) = take_authorized_args(&mut m.attrs) {
-                    if try_instrument_method(m, &args).is_some() {
+                    if instrument_impl_like(&m.sig, &mut m.block, &m.sig.ident, &args, true) {
                         had_authorized = true;
                     }
                 }

--- a/access-control-macros/src/lib.rs
+++ b/access-control-macros/src/lib.rs
@@ -146,7 +146,7 @@ fn instrument_block_multi(
 
 /// 1) Finds and removes the instances of #[authorized_by(...)] in attrs,
 /// 2) parses it into AuthorizedArgs and pushes it to the output vector,
-/// 3) returns the output vector contained the authorizaed args (or None if malformed attr).
+/// 3) returns the output vector containing the authorized args (or None if malformed attrs).
 fn take_all_authorized_args(attrs: &mut Vec<Attribute>) -> Vec<AuthorizedArgs> {
     let mut out = Vec::new();
     let mut i = 0;

--- a/access-control-macros/src/lib.rs
+++ b/access-control-macros/src/lib.rs
@@ -1,13 +1,20 @@
 //! Proc macros:
 //! - #[access_control] on an `impl` block:
-//!     * Instruments methods marked with #[authorized_by(...)] by injecting guards
-//!       directly into their bodies, and removes the attribute so it isn't forwarded.
-//!     * Emits compile errors if any public fn is missing #[no_access_control]
-//!       or #[authorized_by(...)].
-//! - #[no_access_control] on a function: marker (no-op).
+//!     * Finds and consumes every `#[authorized_by(arg_ident, check_fn_or_path)]` on each method,
+//!       then injects a single combined guard at the top of the method body. All predicates are
+//!       ANDed together and, if they pass, each subject gets `require_auth()` before the original body.
+//!     * Enforces policy: every public method must have **either** `#[no_access_control]` **or**
+//!       one-or-more `#[authorized_by(..)]`. Mixing both on the same method is an error.
+//!     * Detects “public” as: trait impl methods, `#[contractimpl]` methods, or methods with `pub` visibility.
+//!     * Uses hybrid `Env` resolution (prefer a parameter named `env`, else a unique `Env`-typed param).
+//!
+//! - #[no_access_control] on a function:
+//!     * Marker (no-op) indicating the method is intentionally open (no guard injected).
+//!
 //! - #[authorized_by(arg_ident, check_fn_or_path)] on a function:
-//!     * If applied directly to a function/impl method, injects the guard.
-//!     * If it lands on a generated wrapper or non-function item, it no-ops (warns at most).
+//!     * Syntax-only attribute when used standalone (left in place); instrumentation is performed
+//!       locally by `#[access_control]` so expansion order with other macros stays predictable.
+
 
 extern crate proc_macro;
 
@@ -17,9 +24,10 @@ use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    Attribute, FnArg, ImplItem, ImplItemFn, ItemFn, ItemImpl, Meta, Pat, Path, Token, Type,
+    Attribute, FnArg, ImplItem, ItemImpl, Meta, Pat, Path, Token, Type,
     Visibility,
 };
+use std::collections::BTreeSet;
 
 use proc_macro_error::{abort, abort_if_dirty, emit_error, emit_warning, proc_macro_error};
 
@@ -57,11 +65,6 @@ fn find_param_ident(sig: &syn::Signature, desired: &str) -> Option<syn::Ident> {
         },
         FnArg::Receiver(_) => None, // skip for 'self'
     })
-}
-
-/// Returns true if desired parameter exists within the function signature.
-fn param_exists(sig: &syn::Signature, desired: &syn::Ident) -> bool {
-    find_param_ident(sig, &desired.to_string()).is_some()
 }
 
 /// Return the parameter identifiers whose *spelled* type is `Env` (or `&Env`, or `soroban_sdk::Env`).
@@ -103,57 +106,76 @@ fn find_env_ident_hybrid(sig: &syn::Signature) -> Option<syn::Ident> {
     }
 }
 
-/// Returns a boxed block that:
-/// 1) runs the predicate,
-/// 2) calls `require_auth()` on the subject,
-/// 3) then executes the original body.
-fn instrument_block(
+/// Builds a new function body that enforces every `#[authorized_by(...)]` guard on the target
+/// All predicates are evaluated together, and if any predicate returns `false`, the call panics as unauthorized.
+/// After the combined checks pass, `require_auth()` is invoked for each distinct address, and then the
+/// original body is executed unchanged.
+fn instrument_block_multi(
     body: &syn::Block,
-    call_path: TokenStream2,
+    pairs: &[(TokenStream2, syn::Ident)], // (call_path, arg_ident)
     env_ident: &syn::Ident,
-    arg_ident: &syn::Ident,
     span: Span,
 ) -> Box<syn::Block> {
+    // Iterate through the auth_pairs and build check1(&env, &a1) && check2(&env, &a2) && ...
+    let checks = pairs.iter().map(|(call_path, arg)| {
+        quote! { #call_path(&#env_ident, &#arg) }
+    });
+
+    // Iterate and build a1.require_auth(); a2.require_auth(); ...
+    // Also dedupe calls for require_auth on addresses featuring multiple times in `auths`.
+    let mut seen = BTreeSet::<String>::new();
+    let auths = pairs.iter().filter_map(|(_, arg)| {
+        let k = arg.to_string();
+        if seen.insert(k) {
+            Some(quote! { #arg.require_auth(); })
+        } else {
+            None
+        }
+    });
+
     syn::parse_quote_spanned! { span =>
         {
-            if !(#call_path(&#env_ident, &#arg_ident)) {
-                ::core::panic!(concat!(
-                    "unauthorized: ",
-                    stringify!(#call_path),
-                    "(env,",
-                    stringify!(#arg_ident),
-                    ") failed"
-                ));
+            if !(true #(&& (#checks))* ) {
+                ::core::panic!("unauthorized: one or more authorization predicates failed");
             }
-            #arg_ident.require_auth();
+            #(#auths)*
             #body
         }
     }
 }
 
-/// 1) Finds and removes the first #[authorized_by(...)] in attrs,
-/// 2) parses it into AuthorizedArgs,
-/// 3) returns Some(args) (or None if malformed attr).
-fn take_authorized_args(attrs: &mut Vec<Attribute>) -> Option<AuthorizedArgs> {
-    let idx = attrs.iter().position(|a| a.path().is_ident("authorized_by"))?;
-    let attr = attrs.remove(idx);
-    match attr.meta {
-        Meta::List(_) => match attr.parse_args::<AuthorizedArgs>() {
-            Ok(a) => Some(a),
-            Err(e) => {
-                emit_error!(attr.span(), "malformed #[authorized_by(...)] args: {}", e);
-                None
+
+/// 1) Finds and removes the instances of #[authorized_by(...)] in attrs,
+/// 2) parses it into AuthorizedArgs and pushes it to the output vector,
+/// 3) returns the output vector contained the authorizaed args (or None if malformed attr).
+fn take_all_authorized_args(attrs: &mut Vec<Attribute>) -> Vec<AuthorizedArgs> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < attrs.len() {
+        if attrs[i].path().is_ident("authorized_by") {
+            let attr = attrs.remove(i);
+            match attr.meta {
+                Meta::List(_) => match attr.parse_args::<AuthorizedArgs>() {
+                    Ok(a) => out.push(a),
+                    Err(e) => {
+                        emit_error!(attr.span(), "malformed #[authorized_by(...)] args: {}", e);
+                    }
+                },
+                _ => {
+                    emit_error!(
+                        attr.span(),
+                        "#[authorized_by] must be written as #[authorized_by(arg_ident, path)]"
+                    );
+                }
             }
-        },
-        _ => {
-            emit_error!(
-                attr.span(),
-                "#[authorized_by] must be written as #[authorized_by(arg_ident, path)]"
-            );
-            None
+            // do not i += 1 here because we just removed current slot
+        } else {
+            i += 1;
         }
     }
+    out
 }
+
 
 fn build_call_path(check_fn: &Path, use_self: bool) -> TokenStream2 {
     if use_self && check_fn.segments.len() == 1 {
@@ -187,8 +209,9 @@ fn get_env_ident_or_warn(sig: &syn::Signature, fn_name: &syn::Ident) -> Option<s
     None
 }
 
+/// Returns true if desired parameter exists within the function signature otherwise emits a warning and returns false.
 fn ensure_param_or_warn(sig: &syn::Signature, fn_name: &syn::Ident, desired: &syn::Ident) -> bool {
-    if param_exists(sig, desired) {
+    if find_param_ident(sig, &desired.to_string()).is_some() {
         return true;
     }
     emit_warning!(
@@ -197,88 +220,96 @@ fn ensure_param_or_warn(sig: &syn::Signature, fn_name: &syn::Ident, desired: &sy
         desired,
         fn_name
     );
+
     false
 }
 
-///
-fn instrument_impl_like(
+fn instrument_impl_like_multi(
     sig: &syn::Signature,
     block: &mut syn::Block,
     fn_name: &syn::Ident,
-    args: &AuthorizedArgs,
+    args_list: &[AuthorizedArgs],
     use_self: bool,
 ) -> bool {
-    if !ensure_param_or_warn(sig, fn_name, &args.arg) {
+    if args_list.is_empty() {
         return false;
     }
+
+    // Ensure each named param exists; if any missing, skip entirely (warned inside).
+    for args in args_list {
+        if !ensure_param_or_warn(sig, fn_name, &args.arg) {
+            return false;
+        }
+    }
+
+    // Resolve Env once.
     let env_ident = match get_env_ident_or_warn(sig, fn_name) {
         Some(e) => e,
         None => return false,
     };
-    let call_path = build_call_path(&args.check_fn, use_self);
-    let arg = &args.arg;
+
+    // Build (call_path, arg_ident) pairs.
+    let pairs: Vec<(TokenStream2, syn::Ident)> = args_list
+        .iter()
+        .map(|a| (build_call_path(&a.check_fn, use_self), a.arg.clone()))
+        .collect();
+
     let body = &*block; // borrow before replace
-    *block = *instrument_block(body, call_path, &env_ident, arg, sig.span());
+    *block = *instrument_block_multi(body, &pairs, &env_ident, sig.span());
     true
 }
 
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let args = match syn::parse::<AuthorizedArgs>(attr) {
-        Ok(a) => a,
-        Err(e) => {
-            emit_error!(e.span(), "malformed #[authorized_by(..)]: {}", e);
-            return item;
-        }
-    };
-
-    // impl method path
-    if let Ok(mut m) = syn::parse::<ImplItemFn>(item.clone()) {
-        let _ = instrument_impl_like(&m.sig, &mut m.block, &m.sig.ident, &args, /*use_self=*/ true);
-        return TokenStream::from(quote!(#m));
+    // Validate syntax but do not instrument here. This is because when evaluating multiple authorized_by attributes
+    // it can cause issues of double instrumentation when #[access_control] processes it later. To avoid any ugly errors 
+    // and enforced policies in a single location, the macro instrumentation is uniformly handled through access_control
+    if let Err(e) = syn::parse::<AuthorizedArgs>(attr) {
+        emit_error!(e.span(), "malformed #[authorized_by(..)]: {}", e);
     }
-
-    // free function path
-    if let Ok(mut f) = syn::parse::<ItemFn>(item.clone()) {
-        let _ = instrument_impl_like(&f.sig, &mut f.block, &f.sig.ident, &args, /*use_self=*/ false);
-        return TokenStream::from(quote!(#f));
-    }
-
-    // Not a function/method → no-op
     item
 }
 
-/// Apply to an `contractimpl` block.
-/// Instruments #[authorized_by(...)] in place and removes the attribute;
-/// then enforces that public functions have either #[no_access_control]
-/// or #[authorized_by(...)].
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn access_control(_attr: TokenStream, item: TokenStream) -> TokenStream {
     if let Ok(mut impl_block) = syn::parse::<ItemImpl>(item.clone()) {
         for it in &mut impl_block.items {
             if let ImplItem::Fn(m) = it {
-                // instrument & strip #[authorized_by(...)] if present
+                // Pull out *all* authorized_by(...) attributes now
+                let auth_args = take_all_authorized_args(&mut m.attrs);
+                let has_no_access = has_no_access_attr(&m.attrs);
+
+                // Enforce either ONLY #[no_access_control], or one-or-more #[authorized_by(..)]
+                if has_no_access && !auth_args.is_empty() {
+                    emit_error!(
+                        m.sig.ident.span(),
+                        "cannot combine #[no_access_control] with #[authorized_by(..)] on `{}`; \
+                         use one or the other",
+                        m.sig.ident
+                    );
+                }
+
+                // If we have any authorized_by(..), instrument with *all* predicates
                 let mut had_authorized = false;
-                if let Some(args) = take_authorized_args(&mut m.attrs) {
-                    if instrument_impl_like(&m.sig, &mut m.block, &m.sig.ident, &args, true) {
+                if !auth_args.is_empty() {
+                    if instrument_impl_like_multi(&m.sig, &mut m.block, &m.sig.ident, &auth_args, true) {
                         had_authorized = true;
                     }
                 }
 
+                // Public-surface detection (trait impl, contractimpl, or explicit pub)
                 let is_trait_impl = impl_block.trait_.is_some();
                 let has_contractimpl_attr = impl_block
                     .attrs
                     .iter()
                     .any(|a| a.path().is_ident("contractimpl"));
-
                 let is_public = is_trait_impl
                     || has_contractimpl_attr
                     || !matches!(m.vis, Visibility::Inherited);
 
-                let has_no_access = has_no_access_attr(&m.attrs);
-
+                // Enforce that every public fn is either open or protected
                 if is_public && !(had_authorized || has_no_access) {
                     emit_error!(
                         m.sig.ident.span(),

--- a/access-control-macros/src/lib.rs
+++ b/access-control-macros/src/lib.rs
@@ -1,8 +1,8 @@
 //! Proc macros:
-//! - #[access_control] on an `impl` block (or inline `mod`):
+//! - #[access_control] on an `impl` block:
 //!     * Instruments methods marked with #[authorized_by(...)] by injecting guards
 //!       directly into their bodies, and removes the attribute so it isn't forwarded.
-//!     * Emits compile errors if any public-ish fn is missing #[no_access_control]
+//!     * Emits compile errors if any public fn is missing #[no_access_control]
 //!       or #[authorized_by(...)].
 //! - #[no_access_control] on a function: marker (no-op).
 //! - #[authorized_by(arg_ident, check_fn_or_path)] on a function:
@@ -17,13 +17,11 @@ use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    Attribute, FnArg, ImplItem, ImplItemFn, Item, ItemFn, ItemImpl, ItemMod, Meta, Pat, Path,
-    Token, Visibility,
+    Attribute, FnArg, ImplItem, ImplItemFn, Item, ItemFn, ItemImpl, Meta, Pat, Path, Token, Type,
+    Visibility,
 };
 
-use proc_macro_error::{
-    abort, abort_if_dirty, emit_error, emit_warning, proc_macro_error,
-};
+use proc_macro_error::{abort, abort_if_dirty, emit_error, emit_warning, proc_macro_error};
 
 fn has_no_access_attr(attrs: &[Attribute]) -> bool {
     attrs.iter().any(|a| a.path().is_ident("no_access_control"))
@@ -76,6 +74,45 @@ fn find_param_ident(sig: &syn::Signature, name: &str) -> Option<syn::Ident> {
         }
     }
     None
+}
+
+/// Return the parameter identifiers whose *spelled* type is `Env` (or `&Env`, or `soroban_sdk::Env`).
+fn env_type_candidates(sig: &syn::Signature) -> Vec<syn::Ident> {
+    let mut out = Vec::new();
+    for arg in &sig.inputs {
+        let FnArg::Typed(pat_ty) = arg else { continue };
+        let Pat::Ident(pat_ident) = &*pat_ty.pat else { continue };
+
+        // peel references like &Env
+        let mut ty: &Type = &*pat_ty.ty;
+        if let Type::Reference(r) = ty {
+            ty = &*r.elem;
+        }
+        if let Type::Path(p) = ty {
+            if let Some(seg) = p.path.segments.last() {
+                if seg.ident == "Env" {
+                    out.push(pat_ident.ident.clone());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Hybrid Env resolution:
+/// 1) If a parameter literally named `env` exists, use it.
+/// 2) Else, if exactly one parameter has type `Env` (by spelled name), use it.
+/// 3) Else, return None (caller may warn/error).
+fn find_env_ident_hybrid(sig: &syn::Signature) -> Option<syn::Ident> {
+    if let Some(id) = find_param_ident(sig, "env") {
+        return Some(id);
+    }
+    let cands = env_type_candidates(sig);
+    if cands.len() == 1 {
+        Some(cands[0].clone())
+    } else {
+        None
+    }
 }
 
 fn instrument_block(
@@ -133,14 +170,25 @@ fn try_instrument_method(m: &mut ImplItemFn, args: &AuthorizedArgs) -> Option<()
         );
         return None;
     }
-    let env_ident = match find_param_ident(&m.sig, "env") {
+    let env_ident = match find_env_ident_hybrid(&m.sig) {
         Some(id) => id,
         None => {
-            emit_warning!(
-                m.sig.span(),
-                "skipping #[authorized_by]: no `env` parameter found on `{}`; leaving unchanged",
-                m.sig.ident
-            );
+            // See if we can give a better hint (ambiguous vs missing) for ergonomics
+            let cands = env_type_candidates(&m.sig);
+            if cands.len() > 1 {
+                emit_warning!(
+                    m.sig.span(),
+                    "skipping #[authorized_by]: multiple `Env`-typed parameters on `{}`; \
+                     please name the desired one `env`",
+                    m.sig.ident
+                );
+            } else {
+                emit_warning!(
+                    m.sig.span(),
+                    "skipping #[authorized_by]: no `Env` parameter found on `{}`; leaving unchanged",
+                    m.sig.ident
+                );
+            }
             return None;
         }
     };
@@ -154,37 +202,6 @@ fn try_instrument_method(m: &mut ImplItemFn, args: &AuthorizedArgs) -> Option<()
     let arg = &args.arg;
     let body = &m.block;
     m.block = *instrument_block(body, call_path, &env_ident, arg, m.sig.span());
-    Some(())
-}
-
-fn try_instrument_free_fn(f: &mut ItemFn, args: &AuthorizedArgs) -> Option<()> {
-    if !param_exists(&f.sig, &args.arg) {
-        emit_warning!(
-            args.arg.span(),
-            "skipping #[authorized_by]: parameter `{}` not found on function `{}`",
-            args.arg,
-            f.sig.ident
-        );
-        return None;
-    }
-    let env_ident = match find_param_ident(&f.sig, "env") {
-        Some(id) => id,
-        None => {
-            emit_warning!(
-                f.sig.span(),
-                "skipping #[authorized_by]: no `env` parameter found on `{}`; leaving unchanged",
-                f.sig.ident
-            );
-            return None;
-        }
-    };
-    let call_path = {
-        let p = &args.check_fn;
-        quote! { #p }
-    };
-    let arg = &args.arg;
-    let body = &f.block;
-    f.block = instrument_block(body, call_path, &env_ident, arg, f.sig.span());
     Some(())
 }
 
@@ -205,7 +222,7 @@ pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Case 1: method inside an `impl`
     if let Ok(mut m) = syn::parse::<ImplItemFn>(item.clone()) {
         // only instrument if both `env` and requested param exist
-        if let Some(env_ident) = find_param_ident(&m.sig, "env") {
+        if let Some(env_ident) = find_env_ident_hybrid(&m.sig) {
             if param_exists(&m.sig, &args.arg) {
                 let call_path = if args.check_fn.segments.len() == 1 {
                     let ident = &args.check_fn.segments[0].ident;
@@ -216,21 +233,7 @@ pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
                 };
                 let arg = &args.arg;
                 let body = &m.block;
-                m.block = syn::parse_quote_spanned! { m.sig.span()=>
-                    {
-                        if !(#call_path(&#env_ident, &#arg)) {
-                            ::core::panic!(concat!(
-                                "unauthorized: ",
-                                stringify!(#call_path),
-                                "(env,",
-                                stringify!(#arg),
-                                ") failed"
-                            ));
-                        }
-                        #arg.require_auth();
-                        #body
-                    }
-                };
+                m.block = *instrument_block(body, call_path, &env_ident, arg, m.sig.span());
             } else {
                 // param not found – leave unchanged (avoid RA errors)
                 emit_warning!(
@@ -240,38 +243,36 @@ pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
                 );
             }
         } else {
-            // no `env` – leave unchanged (avoid RA errors)
-            emit_warning!(
-                m.sig.span(),
-                "skipping #[authorized_by]: no `env` parameter on `{}`; leaving unchanged",
-                m.sig.ident
-            );
+            let cands = env_type_candidates(&m.sig);
+            if cands.len() > 1 {
+                emit_warning!(
+                    m.sig.span(),
+                    "skipping #[authorized_by]: multiple `Env`-typed parameters on `{}`; \
+                     please name the desired one `env`",
+                    m.sig.ident
+                );
+            } else {
+                emit_warning!(
+                    m.sig.span(),
+                    "skipping #[authorized_by]: no `Env` parameter on `{}`; leaving unchanged",
+                    m.sig.ident
+                );
+            }
         }
         return TokenStream::from(quote!(#m));
     }
 
     // Case 2: free function
     if let Ok(mut f) = syn::parse::<ItemFn>(item.clone()) {
-        if let Some(env_ident) = find_param_ident(&f.sig, "env") {
+        if let Some(env_ident) = find_env_ident_hybrid(&f.sig) {
             if param_exists(&f.sig, &args.arg) {
-                let call_path = { let p = &args.check_fn; quote! { #p } };
+                let call_path = {
+                    let p = &args.check_fn;
+                    quote! { #p }
+                };
                 let arg = &args.arg;
                 let body = &f.block;
-                f.block = syn::parse_quote_spanned! { f.sig.span()=>
-                    {
-                        if !(#call_path(&#env_ident, &#arg)) {
-                            ::core::panic!(concat!(
-                                "unauthorized: ",
-                                stringify!(#call_path),
-                                "(env,",
-                                stringify!(#arg),
-                                ") failed"
-                            ));
-                        }
-                        #arg.require_auth();
-                        #body
-                    }
-                };
+                f.block = instrument_block(body, call_path, &env_ident, arg, f.sig.span());
             } else {
                 emit_warning!(
                     args.arg.span(),
@@ -280,11 +281,21 @@ pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
                 );
             }
         } else {
-            emit_warning!(
-                f.sig.span(),
-                "skipping #[authorized_by]: no `env` parameter on `{}`; leaving unchanged",
-                f.sig.ident
-            );
+            let cands = env_type_candidates(&f.sig);
+            if cands.len() > 1 {
+                emit_warning!(
+                    f.sig.span(),
+                    "skipping #[authorized_by]: multiple `Env`-typed parameters on `{}`; \
+                     please name the desired one `env`",
+                    f.sig.ident
+                );
+            } else {
+                emit_warning!(
+                    f.sig.span(),
+                    "skipping #[authorized_by]: no `Env` parameter on `{}`; leaving unchanged",
+                    f.sig.ident
+                );
+            }
         }
         return TokenStream::from(quote!(#f));
     }
@@ -293,9 +304,9 @@ pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
 
-/// Apply to an `impl` block (or inline `mod`).
+/// Apply to an `impl` block.
 /// Instruments #[authorized_by(...)] in place and removes the attribute;
-/// then enforces that public-ish functions have either #[no_access_control]
+/// then enforces that public functions have either #[no_access_control]
 /// or #[authorized_by(...)].
 #[proc_macro_error]
 #[proc_macro_attribute]
@@ -318,13 +329,13 @@ pub fn access_control(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     .iter()
                     .any(|a| a.path().is_ident("contractimpl"));
 
-                let is_publicish = is_trait_impl
+                let is_public = is_trait_impl
                     || has_contractimpl_attr
                     || !matches!(m.vis, Visibility::Inherited);
 
                 let has_no_access = has_no_access_attr(&m.attrs);
 
-                if is_publicish && !(had_authorized || has_no_access) {
+                if is_public && !(had_authorized || has_no_access) {
                     emit_error!(
                         m.sig.ident.span(),
                         "public method {} is missing #[no_access_control] or #[authorized_by(...)]",
@@ -337,47 +348,8 @@ pub fn access_control(_attr: TokenStream, item: TokenStream) -> TokenStream {
         return TokenStream::from(quote!(#impl_block));
     }
 
-    // inline module path
-    if let Ok(mut module) = syn::parse::<ItemMod>(item.clone()) {
-        if let Some((_, items)) = &mut module.content {
-            for it in items {
-                if let Item::Fn(f) = it {
-                    let mut f = f;
-                    let mut had_authorized = false;
-
-                    let mut attrs = std::mem::take(&mut f.attrs);
-                    if let Some(args) = take_authorized_args(&mut attrs) {
-                        if try_instrument_free_fn(&mut f, &args).is_some() {
-                            had_authorized = true;
-                        }
-                    }
-                    f.attrs = attrs;
-
-                    let is_publicish = !matches!(f.vis, Visibility::Inherited);
-                    let has_no_access = has_no_access_attr(&f.attrs);
-
-                    if is_publicish && !(had_authorized || has_no_access) {
-                        emit_error!(
-                            f.sig.ident.span(),
-                            "public function {} is missing #[no_access_control] or #[authorized_by(...)]",
-                            f.sig.ident
-                        );
-                    }
-                }
-            }
-            abort_if_dirty();
-            return TokenStream::from(quote!(#module));
-        }
-
-        abort!(
-            module.ident.span(),
-            "#[access_control] cannot be used on external modules; \
-             use it on an `impl` block or an inline `mod`."
-        );
-    }
-
     abort!(
         Span::call_site(),
-        "#[access_control] must be placed on an `impl` block or an inline `mod`."
+        "#[access_control] must be placed on an `impl` block."
     );
 }

--- a/access-control-macros/src/lib.rs
+++ b/access-control-macros/src/lib.rs
@@ -146,18 +146,22 @@ fn instrument_block_multi(
 
 /// 1) Finds and removes the instances of #[authorized_by(...)] in attrs,
 /// 2) parses it into AuthorizedArgs and pushes it to the output vector,
-/// 3) returns the output vector containing the authorized args (or None if malformed attrs).
+/// 3) returns the output vector containing the authorized args (or None for malformed attrs).
 fn take_all_authorized_args(attrs: &mut Vec<Attribute>) -> Vec<AuthorizedArgs> {
-    let mut out = Vec::new();
-    let mut i = 0;
-    while i < attrs.len() {
-        if attrs[i].path().is_ident("authorized_by") {
-            let attr = attrs.remove(i);
+    let mut kept = Vec::with_capacity(attrs.len());
+    let out: Vec<AuthorizedArgs> = attrs
+        .drain(..)
+        .filter_map(|attr| {
+            if !attr.path().is_ident("authorized_by") {
+                kept.push(attr);
+                return None;
+            }
             match attr.meta {
                 Meta::List(_) => match attr.parse_args::<AuthorizedArgs>() {
-                    Ok(a) => out.push(a),
+                    Ok(a) => Some(a),
                     Err(e) => {
                         emit_error!(attr.span(), "malformed #[authorized_by(...)] args: {}", e);
+                        None
                     }
                 },
                 _ => {
@@ -165,15 +169,15 @@ fn take_all_authorized_args(attrs: &mut Vec<Attribute>) -> Vec<AuthorizedArgs> {
                         attr.span(),
                         "#[authorized_by] must be written as #[authorized_by(arg_ident, path)]"
                     );
+                    None
                 }
             }
-            // do not i += 1 here because we just removed current slot
-        } else {
-            i += 1;
-        }
-    }
+        })
+        .collect();
+    *attrs = kept;
     out
 }
+
 
 fn build_call_path(check_fn: &Path, use_self: bool) -> TokenStream2 {
     if use_self && check_fn.segments.len() == 1 {
@@ -262,7 +266,7 @@ fn instrument_impl_like_multi(
 pub fn authorized_by(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Validate syntax but do not instrument here. This is because when evaluating multiple authorized_by attributes
     // it can cause issues of double instrumentation when #[access_control] processes it later. To avoid any ugly errors
-    // and enforced policies in a single location, the macro instrumentation is uniformly handled through access_control
+    // and enforce policies in a single location, the macro instrumentation is uniformly handled through access_control
     if let Err(e) = syn::parse::<AuthorizedArgs>(attr) {
         emit_error!(e.span(), "malformed #[authorized_by(..)]: {}", e);
     }

--- a/access-control-macros/src/lib.rs
+++ b/access-control-macros/src/lib.rs
@@ -90,17 +90,16 @@ fn env_type_candidates(sig: &syn::Signature) -> Vec<syn::Ident> {
     out
 }
 
-/// Hybrid Env resolution:
-/// 1) If a parameter literally named `env` exists, use it.
-/// 2) Else, if exactly one parameter has type `Env` (by spelled name), use it.
-/// 3) Else, return None (caller may warn/error).
+/// Env resolution:
+///  1) The variable must have name `env`
+///  2) Its type has to be `Env` or `&Env` or `&soroban_sdk::Env`
+/// If no such variable is found, return None
 fn find_env_ident_hybrid(sig: &syn::Signature) -> Option<syn::Ident> {
-    if let Some(id) = find_param_ident(sig, "env") {
-        return Some(id);
-    }
+    let id = find_param_ident(sig, "env")?;
     let cands = env_type_candidates(sig);
-    if cands.len() == 1 {
-        Some(cands[0].clone())
+
+    if cands.len() == 1 && cands[0] == id {
+        return Some(id);
     } else {
         None
     }
@@ -177,7 +176,6 @@ fn take_all_authorized_args(attrs: &mut Vec<Attribute>) -> Vec<AuthorizedArgs> {
     *attrs = kept;
     out
 }
-
 
 fn build_call_path(check_fn: &Path, use_self: bool) -> TokenStream2 {
     if use_self && check_fn.segments.len() == 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ impl IncrementContract {
 
     fn only_manager(env: &Env, user: &Address) -> bool {
         let stored: Option<Address> = env.storage().persistent().get(&DataKey::Manager);
-        matches!(stored, Some(ref super_owner) if super_owner == user)
+        matches!(stored, Some(ref manager) if manager == user)
     }
 }
 
@@ -53,10 +53,10 @@ impl IncrementContract {
 
     // Example of a protected method that requires two #[authorized_by] guards to be fulfilled. The macro will inject:
     // i) only_owner(&env, &caller) && caller.require_auth()
-    // ii) only_super_owner(&env, &caller) && caller.require_auth()
-    #[authorized_by(caller, only_owner)]
-    #[authorized_by(caller, only_manager)]
-    pub fn change_owner(env: Env, caller: Address, new_owner: Address) {
+    // ii) only_manager(&env, &caller) && caller.require_auth()
+    #[authorized_by(owner, only_owner)]
+    #[authorized_by(manager, only_manager)]
+    pub fn change_owner(env: Env, owner: Address, manager: Address, new_owner: Address) {
         env.storage().persistent().set(&DataKey::Owner, &new_owner);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 #[contracttype]
 pub enum DataKey {
     Counter(Address),
-    Owner, // owner of the program
-    SuperOwner // super admin
+    Owner,      // owner of the program
+    SuperOwner, // super admin
 }
 
 // Methods that we do not want to be public
@@ -50,10 +50,12 @@ impl IncrementContract {
         // Ensure the declared owner actually authorized this init call.
         super_owner.require_auth();
 
-        env.storage().persistent().set(&DataKey::SuperOwner, &super_owner);
+        env.storage()
+            .persistent()
+            .set(&DataKey::SuperOwner, &super_owner);
     }
 
-    // Example of a protected method that requires two #[authorized_by] guards to be fulfilled. The macro will inject: 
+    // Example of a protected method that requires two #[authorized_by] guards to be fulfilled. The macro will inject:
     // i) only_owner(&env, &caller) && caller.require_auth()
     // ii) only_super_owner(&env, &caller) && caller.require_auth()
     #[authorized_by(caller, only_owner)]
@@ -77,7 +79,11 @@ impl IncrementContract {
     #[authorized_by(user, only_owner)]
     pub fn increment_owner(environment: Env, user: Address, value: u32) -> u32 {
         let key = DataKey::Counter(user.clone());
-        let mut count: u32 = environment.storage().persistent().get(&key).unwrap_or_default();
+        let mut count: u32 = environment
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_default();
         count += value;
         environment.storage().persistent().set(&key, &count);
         count

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl IncrementContract {
     }
 
     /// Uses the macro guard: Self::only_owner(&env, &user) + user.require_auth()
-    #[no_access_control]
+    // #[no_access_control]
     #[authorized_by(user, only_owner)]
     pub fn increment_owner(env2: Env, user: Address, value: u32) -> u32 {
         let key = DataKey::Counter(user.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 #[contracttype]
 pub enum DataKey {
     Counter(Address),
-    Owner,      // owner of the program
-    SuperOwner, // super admin
+    Owner,   // owner of the program
+    Manager, // manager, intended to add as a guard for transferring owner rights
 }
 
 // Methods that we do not want to be public
@@ -21,8 +21,8 @@ impl IncrementContract {
         matches!(stored, Some(ref owner) if owner == user)
     }
 
-    fn only_super_owner(env: &Env, user: &Address) -> bool {
-        let stored: Option<Address> = env.storage().persistent().get(&DataKey::SuperOwner);
+    fn only_manager(env: &Env, user: &Address) -> bool {
+        let stored: Option<Address> = env.storage().persistent().get(&DataKey::Manager);
         matches!(stored, Some(ref super_owner) if super_owner == user)
     }
 }
@@ -30,9 +30,9 @@ impl IncrementContract {
 #[access_control]
 #[contractimpl]
 impl IncrementContract {
-    // 1) Set owner during deployment/init (one-time).
+    // 1) Constructor to set the owner
     #[no_access_control]
-    pub fn initialize(env: Env, owner: Address) {
+    pub fn __constructor(env: Env, owner: Address) {
         if env.storage().persistent().has(&DataKey::Owner) {
             panic!("already initialized");
         }
@@ -42,24 +42,22 @@ impl IncrementContract {
         env.storage().persistent().set(&DataKey::Owner, &owner);
     }
 
-    #[no_access_control]
-    pub fn initialize_super_owner(env: Env, super_owner: Address) {
-        if env.storage().persistent().has(&DataKey::SuperOwner) {
+    #[authorized_by(caller, only_owner)]
+    pub fn set_manager(env: Env, caller: Address, manager: Address) {
+        if env.storage().persistent().has(&DataKey::Manager) {
             panic!("already initialized");
         }
-        // Ensure the declared owner actually authorized this init call.
-        super_owner.require_auth();
 
         env.storage()
             .persistent()
-            .set(&DataKey::SuperOwner, &super_owner);
+            .set(&DataKey::Manager, &manager);
     }
 
     // Example of a protected method that requires two #[authorized_by] guards to be fulfilled. The macro will inject:
     // i) only_owner(&env, &caller) && caller.require_auth()
     // ii) only_super_owner(&env, &caller) && caller.require_auth()
     #[authorized_by(caller, only_owner)]
-    #[authorized_by(caller, only_super_owner)]
+    #[authorized_by(caller, only_manager)]
     pub fn change_owner(env: Env, caller: Address, new_owner: Address) {
         env.storage().persistent().set(&DataKey::Owner, &new_owner);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#[allow(unused_imports)]
 use access_control_macros::{access_control, authorized_by, no_access_control};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
@@ -6,6 +7,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 pub enum DataKey {
     Counter(Address),
     Owner, // owner of the program
+    SuperOwner // super admin
 }
 
 // Methods that we do not want to be public
@@ -17,6 +19,11 @@ impl IncrementContract {
     fn only_owner(env: &Env, user: &Address) -> bool {
         let stored: Option<Address> = env.storage().persistent().get(&DataKey::Owner);
         matches!(stored, Some(ref owner) if owner == user)
+    }
+
+    fn only_super_owner(env: &Env, user: &Address) -> bool {
+        let stored: Option<Address> = env.storage().persistent().get(&DataKey::SuperOwner);
+        matches!(stored, Some(ref super_owner) if super_owner == user)
     }
 }
 
@@ -35,9 +42,22 @@ impl IncrementContract {
         env.storage().persistent().set(&DataKey::Owner, &owner);
     }
 
-    // 2) Example of a protected method that only the owner can call.
-    //    Your #[authorized_by] macro will inject: only_owner(&env, &caller) && caller.require_auth()
+    #[no_access_control]
+    pub fn initialize_super_owner(env: Env, super_owner: Address) {
+        if env.storage().persistent().has(&DataKey::SuperOwner) {
+            panic!("already initialized");
+        }
+        // Ensure the declared owner actually authorized this init call.
+        super_owner.require_auth();
+
+        env.storage().persistent().set(&DataKey::SuperOwner, &super_owner);
+    }
+
+    // Example of a protected method that requires two #[authorized_by] guards to be fulfilled. The macro will inject: 
+    // i) only_owner(&env, &caller) && caller.require_auth()
+    // ii) only_super_owner(&env, &caller) && caller.require_auth()
     #[authorized_by(caller, only_owner)]
+    #[authorized_by(caller, only_super_owner)]
     pub fn change_owner(env: Env, caller: Address, new_owner: Address) {
         env.storage().persistent().set(&DataKey::Owner, &new_owner);
     }
@@ -53,13 +73,13 @@ impl IncrementContract {
     }
 
     /// Uses the macro guard: Self::only_owner(&env, &user) + user.require_auth()
-    // #[no_access_control]
+    /// Note: here the env is identified by type `Env` instead of the name `env`
     #[authorized_by(user, only_owner)]
-    pub fn increment_owner(env2: Env, user: Address, value: u32) -> u32 {
+    pub fn increment_owner(environment: Env, user: Address, value: u32) -> u32 {
         let key = DataKey::Counter(user.clone());
-        let mut count: u32 = env2.storage().persistent().get(&key).unwrap_or_default();
+        let mut count: u32 = environment.storage().persistent().get(&key).unwrap_or_default();
         count += value;
-        env2.storage().persistent().set(&key, &count);
+        environment.storage().persistent().set(&key, &count);
         count
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,12 +53,13 @@ impl IncrementContract {
     }
 
     /// Uses the macro guard: Self::only_owner(&env, &user) + user.require_auth()
+    #[no_access_control]
     #[authorized_by(user, only_owner)]
-    pub fn increment_owner(env: Env, user: Address, value: u32) -> u32 {
+    pub fn increment_owner(env2: Env, user: Address, value: u32) -> u32 {
         let key = DataKey::Counter(user.clone());
-        let mut count: u32 = env.storage().persistent().get(&key).unwrap_or_default();
+        let mut count: u32 = env2.storage().persistent().get(&key).unwrap_or_default();
         count += value;
-        env.storage().persistent().set(&key, &count);
+        env2.storage().persistent().set(&key, &count);
         count
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,7 @@ impl IncrementContract {
             panic!("already initialized");
         }
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Manager, &manager);
+        env.storage().persistent().set(&DataKey::Manager, &manager);
     }
 
     // Example of a protected method that requires two #[authorized_by] guards to be fulfilled. The macro will inject:
@@ -73,17 +71,12 @@ impl IncrementContract {
     }
 
     /// Uses the macro guard: Self::only_owner(&env, &user) + user.require_auth()
-    /// Note: here the env is identified by type `Env` instead of the name `env`
     #[authorized_by(user, only_owner)]
-    pub fn increment_owner(environment: Env, user: Address, value: u32) -> u32 {
+    pub fn increment_owner(env: Env, user: Address, value: u32) -> u32 {
         let key = DataKey::Counter(user.clone());
-        let mut count: u32 = environment
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or_default();
+        let mut count: u32 = env.storage().persistent().get(&key).unwrap_or_default();
         count += value;
-        environment.storage().persistent().set(&key, &count);
+        env.storage().persistent().set(&key, &count);
         count
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -14,7 +14,9 @@ fn test_increment_auth() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(IncrementContract, ());
+    let owner = Address::generate(&env);
+
+    let contract_id = env.register(IncrementContract, (&owner, ));
     let client = IncrementContractClient::new(&env, &contract_id);
 
     let user_1 = Address::generate(&env);
@@ -51,13 +53,14 @@ fn test_increment_owner_auth() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(IncrementContract, ());
-    let client = IncrementContractClient::new(&env, &contract_id);
-
     let owner = Address::generate(&env);
 
+
+    let contract_id = env.register(IncrementContract, (&owner, ));
+    let client = IncrementContractClient::new(&env, &contract_id);
+
     // Set the owner once during deployment/init.
-    client.initialize(&owner);
+    // client.initialize(&owner);
 
     // This should be successful since owner is authorized to call increment_owner()
     assert_eq!(client.increment_owner(&owner, &5), 5);
@@ -67,15 +70,17 @@ fn test_increment_owner_auth() {
 fn test_change_owner_multi_auth() {
     let env = Env::default();
     env.mock_all_auths();
-
-    let contract_id = env.register(IncrementContract, ());
-    let client = IncrementContractClient::new(&env, &contract_id);
-
     let owner = Address::generate(&env);
 
+    let contract_id = env.register(IncrementContract, (owner.clone(),));
+    let client = IncrementContractClient::new(&env, &contract_id);
+
+    // let owner = Address::generate(&env);
+
     // Set the owner once during deployment/init.
-    client.initialize(&owner);
-    client.initialize_super_owner(&owner);
+    // client.initialize(&owner);
+    // client.__constructor(&owner);
+    client.set_manager(&owner, &owner);
 
     let new_owner = Address::generate(&env);
     // This should be successful since owner and super owner are same.
@@ -89,14 +94,15 @@ fn test_increment_owner_auth_denied_should_panic() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(IncrementContract, ());
-    let client = IncrementContractClient::new(&env, &contract_id);
-
     let owner = Address::generate(&env);
     let other = Address::generate(&env);
 
+    let contract_id = env.register(IncrementContract, (&owner, ));
+    let client = IncrementContractClient::new(&env, &contract_id);
+
+
     // Initialize sets the expected owner.
-    client.initialize(&owner);
+    // client.initialize(&owner);
 
     // This should panic due to the caller not fulfilling onlyOwner() requirements.
     client.increment_owner(&other, &1);
@@ -108,15 +114,16 @@ fn test_change_owner_multi_auth_denied_should_panic() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(IncrementContract, ());
+    let owner = Address::generate(&env);
+    let manager = Address::generate(&env);
+
+    let contract_id = env.register(IncrementContract, (&owner, ));
     let client = IncrementContractClient::new(&env, &contract_id);
 
-    let owner = Address::generate(&env);
-    let super_owner = Address::generate(&env);
-
     // Set the owner once during deployment/init.
-    client.initialize(&owner);
-    client.initialize_super_owner(&super_owner);
+    // client.initialize(&owner);
+    // client.initialize_super_owner(&super_owner);
+    client.set_manager(&owner, &manager);
 
     let new_owner = Address::generate(&env);
     // This should not be successful since the owner and super owner are different

--- a/src/test.rs
+++ b/src/test.rs
@@ -55,11 +55,9 @@ fn test_increment_owner_auth() {
 
     let owner = Address::generate(&env);
 
+    // Set the owner during deployment
     let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
-
-    // Set the owner once during deployment/init.
-    // client.initialize(&owner);
 
     // This should be successful since owner is authorized to call increment_owner()
     assert_eq!(client.increment_owner(&owner, &5), 5);
@@ -70,21 +68,17 @@ fn test_change_owner_multi_auth() {
     let env = Env::default();
     env.mock_all_auths();
     let owner = Address::generate(&env);
+    let manager: Address = Address::generate(&env);
 
-    let contract_id = env.register(IncrementContract, (owner.clone(),));
+    // Set the owner during deployment
+    let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
 
-    // let owner = Address::generate(&env);
-
-    // Set the owner once during deployment/init.
-    // client.initialize(&owner);
-    // client.__constructor(&owner);
-    client.set_manager(&owner, &owner);
+    client.set_manager(&owner, &manager);
 
     let new_owner = Address::generate(&env);
-    // This should be successful since owner and super owner are same.
-    // Therefore the address is authorized to call increment_owner()
-    client.change_owner(&owner, &new_owner);
+    // This should be successful since owner and manager both co-sign to change the manager to a new manager.
+    client.change_owner(&owner, &manager, &new_owner);
 }
 
 #[test]
@@ -96,11 +90,9 @@ fn test_increment_owner_auth_denied_should_panic() {
     let owner = Address::generate(&env);
     let other = Address::generate(&env);
 
+    // Set the owner during deployment
     let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
-
-    // Initialize sets the expected owner.
-    // client.initialize(&owner);
 
     // This should panic due to the caller not fulfilling onlyOwner() requirements.
     client.increment_owner(&other, &1);
@@ -115,15 +107,14 @@ fn test_change_owner_multi_auth_denied_should_panic() {
     let owner = Address::generate(&env);
     let manager = Address::generate(&env);
 
+    // Set the owner once during deployment/init.
     let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
 
-    // Set the owner once during deployment/init.
-    // client.initialize(&owner);
-    // client.initialize_super_owner(&super_owner);
     client.set_manager(&owner, &manager);
 
     let new_owner = Address::generate(&env);
-    // This should not be successful since the owner and super owner are different
-    client.change_owner(&owner, &new_owner);
+    // This should not be successful since the owner and manager do not co-sign on changing the manager.
+    // In this case, the second co-sign is from the new owner, and not the manager.
+    client.change_owner(&owner, &new_owner, &new_owner);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -64,6 +64,26 @@ fn test_increment_owner_auth() {
 }
 
 #[test]
+fn test_change_owner_multi_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IncrementContract, ());
+    let client = IncrementContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+
+    // Set the owner once during deployment/init.
+    client.initialize(&owner);
+    client.initialize_super_owner(&owner);
+
+    let new_owner = Address::generate(&env);
+    // This should be successful since owner and super owner are same.
+    // Therefore the address is authorized to call increment_owner()
+    client.change_owner(&owner, &new_owner);
+}
+
+#[test]
 #[should_panic(expected = "unauthorized")]
 fn test_increment_owner_auth_denied_should_panic() {
     let env = Env::default();
@@ -80,4 +100,25 @@ fn test_increment_owner_auth_denied_should_panic() {
 
     // This should panic due to the caller not fulfilling onlyOwner() requirements.
     client.increment_owner(&other, &1);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_change_owner_multi_auth_denied_should_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IncrementContract, ());
+    let client = IncrementContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let super_owner = Address::generate(&env);
+
+    // Set the owner once during deployment/init.
+    client.initialize(&owner);
+    client.initialize_super_owner(&super_owner);
+
+    let new_owner = Address::generate(&env);
+    // This should note be successful since owner and super owner are different
+    client.change_owner(&owner, &new_owner);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,7 +16,7 @@ fn test_increment_auth() {
 
     let owner = Address::generate(&env);
 
-    let contract_id = env.register(IncrementContract, (&owner, ));
+    let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
 
     let user_1 = Address::generate(&env);
@@ -55,8 +55,7 @@ fn test_increment_owner_auth() {
 
     let owner = Address::generate(&env);
 
-
-    let contract_id = env.register(IncrementContract, (&owner, ));
+    let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
 
     // Set the owner once during deployment/init.
@@ -97,9 +96,8 @@ fn test_increment_owner_auth_denied_should_panic() {
     let owner = Address::generate(&env);
     let other = Address::generate(&env);
 
-    let contract_id = env.register(IncrementContract, (&owner, ));
+    let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
-
 
     // Initialize sets the expected owner.
     // client.initialize(&owner);
@@ -117,7 +115,7 @@ fn test_change_owner_multi_auth_denied_should_panic() {
     let owner = Address::generate(&env);
     let manager = Address::generate(&env);
 
-    let contract_id = env.register(IncrementContract, (&owner, ));
+    let contract_id = env.register(IncrementContract, (&owner,));
     let client = IncrementContractClient::new(&env, &contract_id);
 
     // Set the owner once during deployment/init.

--- a/src/test.rs
+++ b/src/test.rs
@@ -119,6 +119,6 @@ fn test_change_owner_multi_auth_denied_should_panic() {
     client.initialize_super_owner(&super_owner);
 
     let new_owner = Address::generate(&env);
-    // This should note be successful since owner and super owner are different
+    // This should not be successful since the owner and super owner are different
     client.change_owner(&owner, &new_owner);
 }


### PR DESCRIPTION
This PR contains the following changes:

- Removal of support for inline modules. This can be added again if requested.
- There is no strict requirement for an `env` name, it is preferred but if not found the macro defaults to searching for an `Env` type. But only one `Env` type is allowed.
- Added support for multiple authorization guards. This can be used to inject multiple predicates for more advanced authorization composition/requirements. But, as suggested #[no_access_control] and #[authorized_by] cannot coexist on the same method.
- Added tests and modified contracts to support and illustrate the above changes/feature additions.
- Code refactoring to trim redundant code and make the library leaner. The main `access_control` macro is thicker now since the guard implementation was shifted from `authorized_by`. This now performs a lot of the macro instrumentation centrally, and therefore reads better and is easier to reason about. Otherwise most functionality has been split into smaller components.
- Outdated comments have been updated, and new comments have been added wherever deemed fit.